### PR TITLE
Add user api

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,11 +11,6 @@ function App() {
           path="/request/*"
           element={<PrivateRouter element={<P.RequestPage />} />}
         />
-
-        <Route
-          path="/survey/*"
-          element={<PrivateRouter element={<P.SurveyPage />} />}
-        />
         <Route
           path="/"
           element={<PrivateRouter element={<P.ProfilePage />} />}
@@ -25,6 +20,10 @@ function App() {
           element={<PrivateRouter element={<P.NoticePage />} />}
         />
       </Route>
+      <Route
+        path="/survey/*"
+        element={<PrivateRouter element={<P.SurveyPage />} />}
+      />
       <Route path="/signup/*" element={<P.SignupPage />} />
       <Route path="/login" element={<P.LoginPage />} />
       <Route path="/main" element={<P.MainPage />} />

--- a/src/Pages/ProfilePage/index.tsx
+++ b/src/Pages/ProfilePage/index.tsx
@@ -6,6 +6,8 @@ import { UserInfo } from "../../types/user";
 import { Type } from "../../types/type";
 import axiosInstance from "../../libs/api/axiosInstance";
 import { useNavigate } from "react-router-dom";
+import axios, { AxiosError } from "axios";
+import { refresh } from "../../components/api/refresh";
 
 const typeList: Type = {
   PORORO: "뽀로로",
@@ -69,7 +71,7 @@ const ProfilePage = () => {
 
       setUserInfo(response.data);
     } catch (error) {
-      console.error("Error:", error);
+      refresh(naviagte, sendUserRequest);
     }
   };
 

--- a/src/Pages/ProfilePage/index.tsx
+++ b/src/Pages/ProfilePage/index.tsx
@@ -4,6 +4,7 @@ import { RequestList } from "../../components";
 import { ArrowButtonIcon } from "../../Assets/svg";
 import { UserInfo } from "../../types/user";
 import { Type } from "../../types/type";
+import axiosInstance from "../../libs/api/axiosInstance";
 
 const data = {
   id: 12,
@@ -78,6 +79,25 @@ const ProfilePage = () => {
     return () => {
       window.removeEventListener("resize", handleWindowResize);
     };
+  }, []);
+
+  const sendUserRequest = async () => {
+    try {
+      const response = await axiosInstance.get("/user", {
+        headers: {
+          Authorization: `Bearer ${localStorage.getItem("accessToken")}`,
+        },
+        withCredentials: true,
+      });
+
+      console.log("Response:", response.data);
+    } catch (error) {
+      console.error("Error:", error);
+    }
+  };
+
+  useEffect(() => {
+    sendUserRequest();
   }, []);
 
   return (

--- a/src/Pages/ProfilePage/index.tsx
+++ b/src/Pages/ProfilePage/index.tsx
@@ -5,40 +5,7 @@ import { ArrowButtonIcon } from "../../Assets/svg";
 import { UserInfo } from "../../types/user";
 import { Type } from "../../types/type";
 import axiosInstance from "../../libs/api/axiosInstance";
-
-const data = {
-  id: 12,
-  username: "안철수",
-  grade: 1,
-  level: 13,
-  gender: "MALE",
-  type: "PORORO",
-  point: 0,
-  major: "FRONT",
-  requestList: [
-    {
-      requestId: 11,
-      title: "안녕하세요",
-      content: "아니 이거 맞아 내가 할말이 없다",
-      requestType: "TYPE",
-      authorName: "박미리",
-    },
-    {
-      requestId: 12,
-      title: "안녕하세요",
-      content: "아니 이거 맞아 내가 할말이 없다",
-      requestType: "STUDY",
-      authorName: "박미리",
-    },
-    {
-      requestId: 13,
-      title: "안녕하세요",
-      content: "아니 이거 맞아 내가 할말이 없다",
-      requestType: "TYPE",
-      authorName: "박미리",
-    },
-  ],
-};
+import { useNavigate } from "react-router-dom";
 
 const typeList: Type = {
   PORORO: "뽀로로",
@@ -62,13 +29,19 @@ const ProfilePage = () => {
   });
 
   const ref = useRef<HTMLDivElement>(null);
+  const grade =
+    userInfo.grade === "ONE"
+      ? 1
+      : userInfo.grade === "TWO"
+      ? 2
+      : userInfo.grade === "THREE"
+      ? 3
+      : null;
   const gender = userInfo.gender === "MALE" ? "남자" : "여자";
   const type = typeList[userInfo.type! as keyof Type];
   const profileSrc = `src\\Assets\\png\\${userInfo.type}.png`;
 
-  useEffect(() => {
-    setUserInfo(data);
-  }, []);
+  const naviagte = useNavigate();
 
   const handleWindowResize = () =>
     window.innerHeight < 1012 ? setIsScrollable(true) : setIsScrollable(false);
@@ -90,7 +63,11 @@ const ProfilePage = () => {
         withCredentials: true,
       });
 
-      console.log("Response:", response.data);
+      if (response.data.type === null) {
+        naviagte("/survey");
+      }
+
+      setUserInfo(response.data);
     } catch (error) {
       console.error("Error:", error);
     }
@@ -109,7 +86,7 @@ const ProfilePage = () => {
             Level {userInfo.level} {userInfo.username}
           </S.TopInfo>
           <S.BottomInfo>
-            {userInfo.grade}학년 {gender} {type} 유형
+            {grade}학년 {gender} {type} 유형
           </S.BottomInfo>
         </S.InfoBox>
       </S.ProfileBox>

--- a/src/Pages/ProfilePage/index.tsx
+++ b/src/Pages/ProfilePage/index.tsx
@@ -6,7 +6,6 @@ import { UserInfo } from "../../types/user";
 import { Type } from "../../types/type";
 import axiosInstance from "../../libs/api/axiosInstance";
 import { useNavigate } from "react-router-dom";
-import axios, { AxiosError } from "axios";
 import { refresh } from "../../components/api/refresh";
 
 const typeList: Type = {

--- a/src/Pages/SurveyPage/index.tsx
+++ b/src/Pages/SurveyPage/index.tsx
@@ -14,6 +14,7 @@ import EDI from "../../Assets/png/edi.png";
 import { useEffect, useState } from "react";
 import { usePreventLeave } from "../../hooks/usePreventLeave";
 import axiosInstance from "../../libs/api/axiosInstance";
+import { refresh } from "../../components/api/refresh";
 
 const Q = [
   [
@@ -191,7 +192,9 @@ export default function SurveyPage() {
 
       navigate("/");
     } catch (error) {
-      console.error("Error:", error);
+      refresh(navigate, () => {
+        sendType(type);
+      });
     }
   };
 

--- a/src/Pages/SurveyPage/index.tsx
+++ b/src/Pages/SurveyPage/index.tsx
@@ -13,6 +13,7 @@ import LUPI from "../../Assets/png/lupi.png";
 import EDI from "../../Assets/png/edi.png";
 import { useEffect, useState } from "react";
 import { usePreventLeave } from "../../hooks/usePreventLeave";
+import axiosInstance from "../../libs/api/axiosInstance";
 
 const Q = [
   [
@@ -175,6 +176,25 @@ export default function SurveyPage() {
     disablePrevent();
   }, []);
 
+  const sendType = async (type: UserType) => {
+    try {
+      await axiosInstance.put(
+        "/user/type",
+        { type },
+        {
+          headers: {
+            Authorization: `Bearer ${localStorage.getItem("accessToken")}`,
+          },
+          withCredentials: true,
+        }
+      );
+
+      navigate("/");
+    } catch (error) {
+      console.error("Error:", error);
+    }
+  };
+
   return (
     <>
       <Routes>
@@ -296,7 +316,13 @@ export default function SurveyPage() {
         />
         <Route
           path="/result"
-          element={<SurveyResult result={result} navigate={navigate} />}
+          element={
+            <SurveyResult
+              result={result}
+              navigate={navigate}
+              sendType={sendType}
+            />
+          }
         />
       </Routes>
     </>
@@ -438,9 +464,11 @@ function SurveyInfo({
 function SurveyResult({
   result,
   navigate,
+  sendType,
 }: {
   result: UserType | undefined;
   navigate: NavigateFunction;
+  sendType: (type: UserType) => void;
 }) {
   useEffect(() => {
     if (result == null) {
@@ -532,7 +560,13 @@ function SurveyResult({
             <></>
           )}
         </S.SurveyDescriptionBox>
-        <S.SurveyFinishButton>GSMATCH 시작하기</S.SurveyFinishButton>
+        <S.SurveyFinishButton
+          onClick={() => {
+            if (result) sendType(result);
+          }}
+        >
+          GSMATCH 시작하기
+        </S.SurveyFinishButton>
       </S.SurveyResultBox>
     </S.MainContainer>
   );

--- a/src/types/user.ts
+++ b/src/types/user.ts
@@ -3,7 +3,7 @@ import { MyRequest } from "./request";
 export interface UserInfo {
   id: number | null;
   username: string | null;
-  grade: number | null;
+  grade: "ONE" | "TWO" | "THREE" | null;
   level: number | null;
   gender: string | null;
   type: string | null;


### PR DESCRIPTION
## 개요 💡

유저 정보와 유형검사 API를 연동했습니다.

## 작업내용 ⌨️

- 유저 정보를 불러와 Profile 페이지에 매핑시켰습니다.

---

유형검사 로직이 변경되어 회원가입 후 유형검사를 진행하는데 유형 변경 요청시 토큰이 필요하기 때문에

회원가입과 로그인 후 프로필 페이지에 접근할 시 유저 유형이 null 이라면

유형검사 페이지로 리다이렉트 시키는 flow로 변경하였습니다.

---

- 각 요청 실패시 리프레시 요청을 보냅니다.
